### PR TITLE
Components issue fix

### DIFF
--- a/src/Parameters.php
+++ b/src/Parameters.php
@@ -19,7 +19,7 @@ class Parameters{
         
         // Geocoding components parameter
         if( isset($param['components']) && is_array($param['components'])){
-           $param['components'] = self::joinParam( $param['components'], '=', '&');
+           $param['components'] = self::joinParam( $param['components'], ':', '&');
         }   
         ///
         


### PR DESCRIPTION
Reference: https://developers.google.com/places/web-service/autocomplete#place_autocomplete_requests
Values for  'components' section should be assigned through colon.