### PR TITLE
php 7.2 compatibility fix

### DIFF
--- a/src/WebService.php
+++ b/src/WebService.php
@@ -301,10 +301,10 @@ class WebService{
                         
             
             // Validate Endpoint
-            if(!array_key_exists('endpoint', config('googlemaps') )
-                    || !count(config('googlemaps.endpoint') < 1)){
-                throw new \ErrorException('End point must not be empty.');
-            }              
+            if( ! (array_key_exists('endpoint', config('googlemaps') )
+                    && count(config('googlemaps.endpoint')) > 0 ) ) {
+                throw new \ErrorException('Endpoint must not be empty.');
+            }    
                      
                     
     }


### PR DESCRIPTION
PHP 7.2 made this bug surface, but this is not a bug caused by 7.2 but rather it is caused by the parentheses from the count method wrapping the whole expression rather than just the array.

I also made the logic a little more readable. Note that just fixing the parentheses caused another bug with the code where it would throw the exception even though the array did contain 2 items which is the default