### PR TITLE
fixed case and namespace for URLify

### DIFF
--- a/src/Parameters.php
+++ b/src/Parameters.php
@@ -5,7 +5,7 @@
  * @author Alexander Pechkarev <alexpechkarev@gmail.com>
  */
 
-use Jbroadway/Urlify;
+use URLify;
 
 class Parameters{
       
@@ -116,8 +116,8 @@ class Parameters{
             if( !empty( $val )){
                 #self::$urlParam[] = $useKey
                 $allParam[] = $useKey
-                            ? $key . $join .urlencode(Urlify::downcode($val))
-                            : $join .urlencode(Urlify::downcode($val));
+                            ? $key . $join .urlencode(URLify::downcode($val))
+                            : $join .urlencode(URLify::downcode($val));
             }
         } 
         


### PR DESCRIPTION
Fixed the direction of the slash in the use statement

But then realized that the package maker does not use Jbroadway as a namespace, it is just namespaced to "URLify"

Also take note of the first 3 letters being capitalized.. fixed that too