### PR TITLE
Add comma special char replacement

### DIFF
--- a/src/Parameters.php
+++ b/src/Parameters.php
@@ -139,6 +139,7 @@ class Parameters{
     private static function replaceCharacters($allParam)
     {
         // replace special characters
+        $allParam = str_replace(['%2C'], [','], $allParam);
         $allParam = str_replace(['%252C'], [','], $allParam);
         $allParam = str_replace(['%3A'], [':'], $allParam);
         return str_replace(['%7C'], ['|'], $allParam);


### PR DESCRIPTION
I'm not sure if this is a bug fix or not, but recently the distancematrix stopped working for me after I upgraded from `1.0.9` to `6.0`. When I use it like this:

```
$response = GoogleMaps::load('distancematrix')                    
    ->setParam([
        'origins'       => ['32.80829080,-116.93529140'],
        'destinations'  => ['32.83598900,-116.86767200'],
        'mode' => 'driving',
        'units' => 'imperial',
        'language' => 'EN'
    ])
    ->getResponseByKey('rows.elements')['rows'][0];
````
This is the response I get:

`{"elements":[{"status":"NOT_FOUND"}]}`

The cause appears to be that the `joinParam` method in `Parameters.php` is returning the following:

`["origins=32.80829080+percent+2C-116.93529140", "destinations=32.83598900+percent+2C-116.86767200", "mode=driving", "language=EN", "units=imperial"]`

Adding a str_replace for %2C to the `replaceCharacters` method fixes the problem.