### PR TITLE
Update geometry-library to fix curly braces syntax error on 5.8 branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 	"require": {
 		"illuminate/support": "5.8.*",
 		"illuminate/config": "5.8.*",
-		"alexpechkarev/geometry-library" : "1.0.0",
+		"alexpechkarev/geometry-library" : "^1.0.2",
 		"jbroadway/urlify": "^1.1",
 		"ext-json": "*",
 		"ext-curl": "*"


### PR DESCRIPTION
This fixes the "Array and string offset access syntax with curly braces is deprecated" on php >= 7.4
This can be useful for people using 5.8 branch with php version higher than 7.3.
Please merge and create a tag.