### PR TITLE
Feature - add timeouts for curl

### DIFF
--- a/src/WebService.php
+++ b/src/WebService.php
@@ -64,6 +64,26 @@ class WebService{
     */
     protected $verifySSL;
 
+    /*
+    |--------------------------------------------------------------------------
+    | Request's timeout
+    |--------------------------------------------------------------------------
+    |
+    |
+    |
+    */
+    protected $requestTimeout;
+
+    /*
+    |--------------------------------------------------------------------------
+    | Connection timeout
+    |--------------------------------------------------------------------------
+    |
+    |
+    |
+    */
+    protected $connectionTimeout;
+
     /**
      * Setting endpoint
      * @param string $key
@@ -238,6 +258,13 @@ class WebService{
                             ? FALSE
                             : Config::get('googlemaps.ssl_verify_peer');
 
+            // set the timeout for the connect phase
+            $this->connectionTimeout = Config::get("googlemaps.connection_timeout");
+
+            // set the maximum time the transfer is allowed to complete
+            $this->requestTimeout = Config::get("googlemaps.request_timeout");
+
+
             $this->clearParameters();
     }
 
@@ -318,6 +345,8 @@ class WebService{
             curl_setopt($ch,CURLOPT_POSTFIELDS, $isPost );
         }
 
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT,  $this->connectionTimeout);
+        curl_setopt($ch, CURLOPT_TIMEOUT,  $this->requestTimeout);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $this->verifySSL);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);

--- a/src/config/googlemaps.php
+++ b/src/config/googlemaps.php
@@ -28,6 +28,28 @@ return [
     'ssl_verify_peer' => FALSE,
 
     /*
+     |--------------------------------------------------------------------------
+     | CURL's connection timeout
+     |--------------------------------------------------------------------------
+     |
+     | Will be used for all web services to limit
+     | the maximum time tha connection can take in seconds
+     |
+      */
+    'connection_timeout' => 1,
+
+    /*
+     |--------------------------------------------------------------------------
+     | CURL's request timeout
+     |--------------------------------------------------------------------------
+     |
+     | Will be used for all web services to limit
+     | the maximum time a request can take
+     |
+      */
+    'request_timeout' => 5,
+
+    /*
     |--------------------------------------------------------------------------
     | Service URL
     |--------------------------------------------------------------------------

--- a/src/config/googlemaps.php
+++ b/src/config/googlemaps.php
@@ -36,7 +36,7 @@ return [
      | the maximum time tha connection can take in seconds
      |
       */
-    'connection_timeout' => 1,
+    'connection_timeout' => 5,
 
     /*
      |--------------------------------------------------------------------------
@@ -47,7 +47,7 @@ return [
      | the maximum time a request can take
      |
       */
-    'request_timeout' => 5,
+    'request_timeout' => 30,
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
This PR resolves the issue of timeouts when the google service is not responding in a reasonable time, this can cause high load on the server when handling many requests.

Added a connection timeout with default 1 second and a request timeout with 5 seconds.